### PR TITLE
chore(deps): migration vers Django 6.1

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,12 +1,12 @@
 # Architecture
 
-Site personnel de Benbb96 : un projet **Django 5.2** monolithique qui regroupe plusieurs
+Site personnel de Benbb96 : un projet **Django 6.1** monolithique qui regroupe plusieurs
 mini-applications indépendantes. Bilingue **FR/EN**, sans étape de build front, déployé sur
 PythonAnywhere.
 
 ## Stack
 
-- **Backend** : Django 5.2, Python 3.13 (prod), **SQLite** (dev et prod).
+- **Backend** : Django 6.1, Python 3.13 (prod), **SQLite** (dev et prod).
 - **Front** : **design system CSS maison** (custom properties, flexbox/grid, `<dialog>`, `:has()`) —
   **sans framework** (pas de Bootstrap) ni **jQuery**, pas de bundler. Dark mode complet.
 - **JS** : vanilla. [Tom Select](https://tom-select.js.org/) (selects searchable), Chart.js v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Contexte
 
-Site personnel de Benbb96 (benbb96.com) : un projet Django 5.2 monolithique qui regroupe plusieurs
+Site personnel de Benbb96 (benbb96.com) : un projet Django 6.1 monolithique qui regroupe plusieurs
 mini-applications indépendantes (avis, musique, trackers, kendama…). Le site est **bilingue FR/EN**
 et l'UI comme les commentaires sont **en français** — écrire en français par défaut.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Benbb96/benbb96-website is built on the following main stack:
 
 **Backend**
 - <img width='25' height='25' src='https://img.stackshare.io/service/993/pUBY5pVj.png' alt='Python'/> [Python](https://www.python.org) – Language
-- <img width='25' height='25' src='https://img.stackshare.io/service/994/4aGjtNQv.png' alt='Django'/> [Django](https://www.djangoproject.com/) 5.2 – Web framework (full stack)
+- <img width='25' height='25' src='https://img.stackshare.io/service/994/4aGjtNQv.png' alt='Django'/> [Django](https://www.djangoproject.com/) 6.1 – Web framework (full stack)
 - [Django REST Framework](https://www.django-rest-framework.org/) + [SimpleJWT](https://django-rest-framework-simplejwt.readthedocs.io/) – REST API + JWT auth (mobile app & external Vue frontends)
 - <img width='25' height='25' src='https://img.stackshare.io/service/2180/1284191.png' alt='Pandas'/> [Pandas](http://pandas.pydata.org/) (via [django-pandas](https://github.com/chrisdev/django-pandas)) – Time-series resampling (tracker)
 - <img width='25' height='25' src='https://img.stackshare.io/service/2375/default_1f67b0ca7416a9f52beb655f90b5602d5ef74b75.jpg' alt='Pillow'/> [Pillow](https://python-pillow.github.io/) – On-upload image optimization (resize + WebP)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Site web personnel de Benbb96 (Django)"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "Django==5.2.16",
+    "Django==6.1",
     "django-admin-sortable",  # fork LEAGUEDORA — voir [tool.uv.sources]
     "django-anymail==13.0",
     "django-autoslug==1.9.9",

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = "==5.2.16" },
+    { name = "django", specifier = "==6.1" },
     { name = "django-admin-sortable", git = "https://github.com/LEAGUEDORA/django-admin-sortable.git" },
     { name = "django-anymail", specifier = "==13.0" },
     { name = "django-autoslug", specifier = "==1.9.9" },
@@ -452,16 +452,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.16"
+version = "6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/26/889449d521ae508b26de715954faecd8bcf3f740affb81b2d146a83b42a5/django-5.2.16.tar.gz", hash = "sha256:59ea02020c3136fce14bef0bbece21a10a4febef5eed1c51c22ae468efa22200", size = 10890894, upload-time = "2026-07-07T13:52:17.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/42/6cb20996733984c1f6661daeda3877990836c76c633c6c8879d39f7120eb/django-6.1.tar.gz", hash = "sha256:86a2aacd59b817e4d6ac2ebfe22356c58f66f7b24e503f71b7c2fead677ee48b", size = 11223034, upload-time = "2026-08-05T19:21:53.789Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/13/1e5e3e4c15dcecb04281b3cb2a46a4670e1cef131068e202f6040df19224/django-5.2.16-py3-none-any.whl", hash = "sha256:04f354bf9d807a86ad1a8392fe3808d362358a8eafc322848e0e43e59b24371d", size = 8311943, upload-time = "2026-07-07T13:52:11.223Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9c/ce847620134cfab903e75690c498af73b46abbede2912ea89bd76d5c1e76/django-6.1-py3-none-any.whl", hash = "sha256:6c132cd980c9392b06807d4ca52d72530d631dc65a85d9dacede00a780cefbbe", size = 8417399, upload-time = "2026-08-05T19:21:47.285Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Migration de **Django 5.2.16 → 6.1** (dernière stable).

## Validation
- ✅ Résolution des dépendances OK avec `uv lock` — aucun blocage, forks (`django-admin-sortable`, `soundcloud`) et `django-autoslug` compris.
- ✅ `manage.py check` clean.
- ✅ `makemigrations --check --dry-run` : **aucune migration** à générer.
- ✅ **27/27 smoke tests** verts.
- ✅ Dépréciation `RemovedInDjango60Warning` sur `forms.URLField` (schéma par défaut `http` → `https`) désormais appliquée et acceptée (7 champs modèles, liens externes).

## Hors périmètre (à traiter plus tard, non bloquant)
- `RemovedInDjango70` : `EMAIL_FILE_PATH` → migrer vers `MAILERS` avant Django 7 (settings dev).
- `UnorderedObjectListWarning` (pré-existant, non lié à la 6) sur la pagination de `Musique`/`Produit`/`Structure` — ajouter un `ordering`.

## Note LTS
6.1 n'est pas une LTS (support sécurité ~déc. 2027). Prochain jalon : re-bump vers **6.2 LTS** (~avril 2027).